### PR TITLE
Add Framework constructor for customizations

### DIFF
--- a/extensions/Framework.cfc
+++ b/extensions/Framework.cfc
@@ -11,8 +11,12 @@ component extends="framework.one" {
 		, trace = true
 	};
 	
-	// this is not getting processed
-	addRoute( '/a', '/main/home' );
+	function init( config = {} ) {
+		super.init( config );
+		// this is not getting processed
+		addRoute( '/a', '/main/home' );
+		return this;
+	}
 	
 	public any function setupApplication() {
 	}	


### PR DESCRIPTION
Since `new Framework()` is being passed routes, you need to invoke `addRoute()` inside `Framework`'s constructor, _after_ the `config` has been appended to the default `variables.framework`.